### PR TITLE
docs: corrected python call with correct path.

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,4 +6,4 @@ A tool to clean sales data from a CSV file.
 
 To run the script, use the command:
 
-`python formatter.py`
+`python src/formatter.py`


### PR DESCRIPTION
The README file contained the wrong python command: the formatter.py script is located in the src/ directory.

Changes
- README.md: `python formatter.py` -> `python src/formatter.py`